### PR TITLE
Save mmseqs_clust object from chop-genome

### DIFF
--- a/meet-neighbors/main.py
+++ b/meet-neighbors/main.py
@@ -266,7 +266,7 @@ def run(parser):
         args.genomes,args.out = dirs_l[0],dirs_l[1]
 
         genome_queries = [genome.split('/')[-1].split('.gff')[0] for genome in glob.glob(args.genomes + '*') if '.gff' in genome]
-        logger.debug(f"All genome names to get neighborhoods from:\n{genome_queries}")
+        logger.debug(f"All genome names to get neighborhoods from: {genome_queries}")
 
         neighborhood_db = db.map(n.get_neigborhood,logger,args,genome_query = db.from_sequence(genome_queries,npartitions=args.threads))
         neighborhood_db = neighborhood_db.flatten()
@@ -280,6 +280,7 @@ def run(parser):
             for fasta in combinedfastas:
                 records = glm.SeqIO.parse(fasta, "fasta")
                 glm.SeqIO.write(records, outfile, "fasta")
+        logger.debug(f"Combined fastas into {singular_combinedfasta}")
 
         # i think its fasta to open the singular combined fasta and loop once, then looping through the records of each partition, didnt test this tho!
         allids = [rec.id for rec in glm.SeqIO.parse(singular_combinedfasta,"fasta")]
@@ -288,21 +289,16 @@ def run(parser):
         mmseqs_clust = pd.DataFrame([allids,allids]).T
         mmseqs_clust.columns = ['rep','locus_tag'] 
         mmseqs_clust = pn.prep_cluster_tsv(mmseqs_clust,logger)
+        logger.debug(f"Total number of queries: {len(mmseqs_clust['query'])}")
         logger.debug(f"Total number of neighborhoods: {len(mmseqs_clust['neighborhood_name'])}")
 
         # b/c we didnt do an initial search all VF centers are the queries for glm input purposes
         mmseqs_clust['query'] = mmseqs_clust['VF_center'].copy() 
+        subprocess.run(f"mkdir {args.out}clust_res_in_neighborhoods",shell=True,check=True)
+        mmseqs_clust.to_csv(f"{args.out}clust_res_in_neighborhoods/mmseqs_clust.tsv",sep="\t",index=False)
 
         glm_input_out = "glm_inputs"
         subprocess.run(f"mkdir {args.out}{glm_input_out}/",shell=True) # should return an error if the path already exists, don't want to make duplicates
-        
-        singular_combinedfasta = f"{args.out}combined.fasta"
-        with open(singular_combinedfasta,"w") as outfile:
-            for fasta in combinedfastas:
-                records = glm.SeqIO.parse(fasta, "fasta")
-                glm.SeqIO.write(records, outfile, "fasta")
-        logger.debug(f"Combined fastas into {singular_combinedfasta}")
-
 
         # create tsvs for glm inputs, one tsv per protein
         db.map(glm.get_glm_input,query=db.from_sequence(list(set(mmseqs_clust['query'])),npartitions=args.threads),
@@ -322,7 +318,7 @@ def run(parser):
             dirs_l = check_dirs(args.neighborhood_run,args.glm_out,args.glm_in)
             neighborhood_dir,glm_out,glm_in = dirs_l[0],dirs_l[1],dirs_l[2]
 
-        mmseqs_clust = dd.read_csv(f"{neighborhood_dir}clust_res_in_neighborhoods/mmseqs_clust_*.tsv",sep="\t",dtype={'query': 'object'})
+        mmseqs_clust = dd.read_csv(f"{neighborhood_dir}clust_res_in_neighborhoods/mmseqs_clust*.tsv",sep="\t",dtype={'query': 'object'})
         mmseqs_clust = mmseqs_clust.compute()
 
         logger.debug(f"Grabbing gLM from {glm_out} \nGiven these inputs: {glm_in}")

--- a/meet-neighbors/plot_map_neighborhood_res.py
+++ b/meet-neighbors/plot_map_neighborhood_res.py
@@ -12,7 +12,9 @@ import numpy as np
 from scipy.stats import entropy
 import dask.dataframe as dd
 
-def prep_cluster_tsv(mmseqs_res_dir,logger):
+# def prep_cluster_tsv(mmseqs_res_dir,logger):
+def prep_cluster_tsv(mmseqs_res_dir):
+
     #run for mmseqs clustered results
     #example res: '/Users/mn3159/bigpurple/data/pirontilab/Students/Madu/bigdreams_dl/neighborhood_call/neighbors_rand5k/neighbors_rand5k_clust_res.tsv'
 
@@ -37,7 +39,7 @@ def prep_cluster_tsv(mmseqs_res_dir,logger):
     mmseqs['cluster'] = mmseqs['rep'].map(cluster_names)
     mmseqs['prot_gffname'] = mmseqs['locus_tag'].str.split('!!!').str[0] + '!!!' + mmseqs['gff']
 
-    logger.info(f"Size of mmseqs cluster results: {mmseqs.shape}")
+    print(f"Size of mmseqs cluster results: {mmseqs.shape}")
     return mmseqs
 
 def map_vfcenters_to_vfdb_annot(prepped_mmseqs_clust,mmseqs_search,vfdb,logger):


### PR DESCRIPTION
Remove redundant code in chop-genome

mmseqs_clust object now saved in clust_res_neighborhoods, similarly to extract-neighbors